### PR TITLE
Allow restarts

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,7 @@
 The following authors have all licensed their contributions to AssemblyScript
 under the licensing terms detailed in LICENSE:
 
+* BrentonGunning <brentongunning@gmail.com>
 * Daniel Wirtz <dcode@dcode.io>
 * Max Graey <maxgraey@gmail.com>
 * Igor Sbitnev <PinkaminaDianePie@gmail.com>

--- a/cli/index.d.ts
+++ b/cli/index.d.ts
@@ -130,6 +130,8 @@ export interface CompilerOptions {
   exportTable?: boolean;
   /** Exports the start function instead of calling it implicitly. */
   exportStart?: string;
+  /** Allows the exported start function to be called repeatedly. */
+  allowRestarts?: boolean;
   /** "Adds one or multiple paths to custom library components. */
   lib?: string | string[];
   /** Adds one or multiple paths to package resolution. */

--- a/cli/index.js
+++ b/cli/index.js
@@ -323,6 +323,7 @@ export async function main(argv, options) {
   if (opts.exportStart != null) {
     assemblyscript.setExportStart(compilerOptions, isNonEmptyString(opts.exportStart) ? opts.exportStart : "_start");
   }
+  assemblyscript.setAllowRestarts(compilerOptions, opts.allowRestarts);
   assemblyscript.setMemoryBase(compilerOptions, opts.memoryBase >>> 0);
   assemblyscript.setTableBase(compilerOptions, opts.tableBase >>> 0);
   assemblyscript.setSourceMap(compilerOptions, opts.sourceMap != null);

--- a/cli/index.js
+++ b/cli/index.js
@@ -34,7 +34,7 @@ import * as optionsUtil from "../util/options.js";
 import * as generated from "./index.generated.js";
 
 import binaryen from "../lib/binaryen.js";
-import * as assemblyscriptJS from "assemblyscript";
+import * as assemblyscriptJS from "@aldea/assemblyscript";
 
 // Use the TS->JS variant by default
 let assemblyscript = assemblyscriptJS;

--- a/cli/options.json
+++ b/cli/options.json
@@ -178,6 +178,14 @@
     ],
     "type": "s"
   },
+  "allowRestarts": {
+    "category": "Features",
+    "description": [
+      "Allows the exported start function to be called more than once."
+    ],
+    "type": "b",
+    "default": false
+  },
   "runtime": {
     "category": "Features",
     "description": [

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -16,8 +16,8 @@ const binaryenUrl = `https://cdn.jsdelivr.net/npm/binaryen@${binaryenVersion}/in
 const longUrl = `https://cdn.jsdelivr.net/npm/long@${longVersion}/index.js`;
 const importmap = {
   "imports": {
-    "assemblyscript": `${distUrl}assemblyscript.js`,
-    "assemblyscript/asc": `${distUrl}asc.js`,
+    "@aldea/assemblyscript": `${distUrl}assemblyscript.js`,
+    "@aldea/assemblyscript/asc": `${distUrl}asc.js`,
     "binaryen": binaryenUrl,
     "long": longUrl
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -255,6 +255,8 @@ export class Options {
   uncheckedBehavior: UncheckedBehavior = UncheckedBehavior.Default;
   /** If given, exports the start function instead of calling it implicitly. */
   exportStart: string | null = null;
+  /** If true, allows the exported start function to be called more than once. */
+  allowRestarts: bool = false;
   /** Static memory start offset. */
   memoryBase: u32 = 0;
   /** Static table start offset. */
@@ -684,7 +686,7 @@ export class Compiler extends DiagnosticEmitter {
     let exportStart = options.exportStart;
     if (!startIsEmpty || exportStart != null) {
       let signature = startFunctionInstance.signature;
-      if (!startIsEmpty && exportStart != null) {
+      if (!startIsEmpty && exportStart != null && !options.allowRestarts) {
         module.addGlobal(BuiltinNames.started, TypeRef.I32, true, module.i32(0));
         startFunctionBody.unshift(
           module.global_set(BuiltinNames.started, module.i32(1))

--- a/src/index-wasm.ts
+++ b/src/index-wasm.ts
@@ -136,6 +136,11 @@ export function setExportStart(options: Options, exportStart: string | null): vo
   options.exportStart = exportStart;
 }
 
+/** Sets the `allowRestarts` option. */
+export function setAllowRestarts(options: Options, allowRestarts: bool): void {
+  options.allowRestarts = allowRestarts;
+}
+
 /** Sets the `noUnsafe` option. */
 export function setNoUnsafe(options: Options, noUnsafe: bool): void {
   options.noUnsafe = noUnsafe;


### PR DESCRIPTION
Changes proposed in this pull request:
⯈ A new `allowRestarts` CLI flag to allow the start function to be called more than once.
⯈ Hook up allowRestarts option to not set the `started` global the first time start is called.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
